### PR TITLE
Suppressed the error thrown to the console on every bot restart

### DIFF
--- a/react_roles/react_roles.py
+++ b/react_roles/react_roles.py
@@ -464,7 +464,8 @@ Gave a total of {g} roles."""
             for entry in link:
                 channel_id, message_id = entry.split("_", 1)
                 role_list.update(self.get_all_roles_from_message(server_id, channel_id, message_id))
-                link_dict[entry] = role_list
+            for entry in link:
+-               link_dict.setdefault(entry, set()).update(role_list)
         self.links[server_id] = link_dict
 
     def remove_links(self, server_id, name):
@@ -472,7 +473,13 @@ Gave a total of {g} roles."""
         link_dict = self.links.get(server_id, {})
         for entry in entry_list:
             if entry in link_dict:
-                del link_dict[entry]
+-               channel_id, message_id = entry.split("_", 1)
++               del link_dict[entry]
+-               role_list = set()
+-               role_list.update(self.get_all_roles_from_message(server_id, channel_id, message_id))
+-               link_dict[entry].difference_update(role_list)
+-               if len(link_dict[entry]) == 0:
+-                   del link_dict[entry]
 
     # Cache -- Needed to keep the actual role object in cache instead of looking for it every time in the server's roles
     def add_to_cache(self, server_id, channel_id, message_id, emoji_str, role):

--- a/react_roles/react_roles.py
+++ b/react_roles/react_roles.py
@@ -423,7 +423,10 @@ Gave a total of {g} roles."""
         await self.bot.wait_until_ready()
         with contextlib.suppress(RuntimeError):  # Suppress the "Event loop is closed" error
             while self == self.bot.get_cog(self.__class__.__name__):
-                key = await self.role_queue.get()
+                try:
+                    key = await self.role_queue.get()
+                except asyncio.CancelledError:
+                    break
                 q = self.role_map.pop(key)
                 if q is not None and q.get("mem") is not None:
                     mem = q["mem"]

--- a/react_roles/react_roles.py
+++ b/react_roles/react_roles.py
@@ -86,7 +86,7 @@ Gave a total of {g} roles."""
         self.links = {}  # {server.id: {channel.id_message.id: [role]}}
         self.processing_wait_time = 0 if self.MAXIMUM_PROCESSED_PER_SECOND == 0 else 1/self.MAXIMUM_PROCESSED_PER_SECOND
         asyncio.ensure_future(self._init_bot_manipulation())
-        asyncio.ensure_future(self.process_role_queue())
+        self.process_task = asyncio.ensure_future(self.process_role_queue())
     
     # Events
     async def on_reaction_add(self, reaction, user):
@@ -152,7 +152,8 @@ Gave a total of {g} roles."""
 
     def __unload(self):
         # This method is ran whenever the bot unloads this cog.
-        pass
+        if self.process_task is not None:
+            self.process_task.cancel()
     
     # Commands
     @commands.group(name="roles", pass_context=True, no_pm=True, invoke_without_command=True)
@@ -421,28 +422,27 @@ Gave a total of {g} roles."""
     async def process_role_queue(self):  # This exists to update multiple roles at once when possible
         """Loops until the cog is unloaded and processes the role assignments when it can"""
         await self.bot.wait_until_ready()
-        with contextlib.suppress(RuntimeError):  # Suppress the "Event loop is closed" error
-            while self == self.bot.get_cog(self.__class__.__name__):
+        while self == self.bot.get_cog(self.__class__.__name__):
+            try:
+                key = await self.role_queue.get()
+            except asyncio.CancelledError:
+                return
+            q = self.role_map.pop(key)
+            if q is not None and q.get("mem") is not None:
+                mem = q["mem"]
+                all_roles = set(mem.roles)
+                add_set = q.get(True, set())
+                del_set = q.get(False, {mem.server.default_role})
                 try:
-                    key = await self.role_queue.get()
-                except asyncio.CancelledError:
-                    break
-                q = self.role_map.pop(key)
-                if q is not None and q.get("mem") is not None:
-                    mem = q["mem"]
-                    all_roles = set(mem.roles)
-                    add_set = q.get(True, set())
-                    del_set = q.get(False, {mem.server.default_role})
-                    try:
-                        await self.bot.replace_roles(mem, *((all_roles | add_set) - del_set))
-                        # Basically, the user's roles + the added - the removed
-                    except (discord.Forbidden, discord.HTTPException):
-                        self.role_map[key] = q  # Try again when it fails
-                        await self.role_queue.put(key)
-                    else:
-                        self.role_queue.task_done()
-                    finally:
-                        await asyncio.sleep(self.processing_wait_time)
+                    await self.bot.replace_roles(mem, *((all_roles | add_set) - del_set))
+                    # Basically, the user's roles + the added - the removed
+                except (discord.Forbidden, discord.HTTPException):
+                    self.role_map[key] = q  # Try again when it fails
+                    await self.role_queue.put(key)
+                else:
+                    self.role_queue.task_done()
+                finally:
+                    await asyncio.sleep(self.processing_wait_time)
         self.logger.debug("The processing loop has ended.")
 
     async def safe_get_message(self, channel, message_id):
@@ -464,8 +464,7 @@ Gave a total of {g} roles."""
             for entry in link:
                 channel_id, message_id = entry.split("_", 1)
                 role_list.update(self.get_all_roles_from_message(server_id, channel_id, message_id))
-            for entry in link:
-                link_dict.setdefault(entry, set()).update(role_list)
+                link_dict[entry] = role_list
         self.links[server_id] = link_dict
 
     def remove_links(self, server_id, name):
@@ -473,12 +472,7 @@ Gave a total of {g} roles."""
         link_dict = self.links.get(server_id, {})
         for entry in entry_list:
             if entry in link_dict:
-                channel_id, message_id = entry.split("_", 1)
-                role_list = set()
-                role_list.update(self.get_all_roles_from_message(server_id, channel_id, message_id))
-                link_dict[entry].difference_update(role_list)
-                if len(link_dict[entry]) == 0:
-                    del link_dict[entry]
+                del link_dict[entry]
 
     # Cache -- Needed to keep the actual role object in cache instead of looking for it every time in the server's roles
     def add_to_cache(self, server_id, channel_id, message_id, emoji_str, role):

--- a/react_roles/react_roles.py
+++ b/react_roles/react_roles.py
@@ -474,7 +474,6 @@ Gave a total of {g} roles."""
         for entry in entry_list:
             if entry in link_dict:
 -               channel_id, message_id = entry.split("_", 1)
-+               del link_dict[entry]
 -               role_list = set()
 -               role_list.update(self.get_all_roles_from_message(server_id, channel_id, message_id))
 -               link_dict[entry].difference_update(role_list)


### PR DESCRIPTION
The react_role cog is awesome, but throws an error on every bot restart, about a task being destroyed while it was pending.

This should solve the issue. Not sure if it there should be `break` or `pass` there, feel free to change if I'm wrong ofc.